### PR TITLE
Enhance LTE RSSI calculations

### DIFF
--- a/include/mgos_pppos.h
+++ b/include/mgos_pppos.h
@@ -126,9 +126,6 @@ struct mg_str mgos_pppos_get_iccid(int if_instance);
 
 extern char sysmode_e[9];
 extern char operator_e[25];
-<<<<<<< Updated upstream
-extern int rssi_e;
-=======
 
 extern int rssi_e;
 extern int rsrp_e;
@@ -138,7 +135,6 @@ extern int rsrq_e;
 extern const char SYSMODE_NOSERVICE[];
 extern const char SYSMODE_GSM[];
 extern const char SYSMODE_CAT_M1[];
->>>>>>> Stashed changes
 
 #ifdef __cplusplus
 }

--- a/include/mgos_pppos.h
+++ b/include/mgos_pppos.h
@@ -126,7 +126,19 @@ struct mg_str mgos_pppos_get_iccid(int if_instance);
 
 extern char sysmode_e[9];
 extern char operator_e[25];
+<<<<<<< Updated upstream
 extern int rssi_e;
+=======
+
+extern int rssi_e;
+extern int rsrp_e;
+extern int sinr_e;
+extern int rsrq_e;
+
+extern const char SYSMODE_NOSERVICE[];
+extern const char SYSMODE_GSM[];
+extern const char SYSMODE_CAT_M1[];
+>>>>>>> Stashed changes
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Description: LTE signal values are calculated differently than GSM: The LTE signal calculation is a combination of RSSI, RSRP and SINR values so we need to make these available.

References:
- eatabit/eatabit-firmware-v6 PR: https://github.com/eatabit/eatabit-firmware-v6/pull/90
- https://www.digi.com/resources/documentation/digidocs/90002344/supplemental/r-signal-bars-explained.htm?TocPath=Welcome%7C_____7